### PR TITLE
fixed GET /user to always return 200

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -23,8 +23,6 @@ class App extends Component {
     getUser () {
         getUser().then((user) => {
             this.setState({user})
-        }).catch((err) => {
-            // ignore!
         })
     }
 

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -78,7 +78,7 @@ module.exports.signup = function (fields) {
 
 module.exports.getUser = function () {
     return get('/user')
-        .then( function (user) {
+        .then( function ({ user }) {
             analytics.setRecordedUser(user)
             return user
         })

--- a/routes/authentication.js
+++ b/routes/authentication.js
@@ -1,11 +1,10 @@
 module.exports = function (app, passport) {
     const { User }= require('../models')
+
     app.get('/user', (req, res) => {
-        if (!req.user) {
-            return res.status(400).send()
-        }
-        const {email, firstName, lastName, isSuperuser} = req.user
-        return res.status(200).send({email,firstName, lastName, isSuperuser})
+        const {email, firstName, lastName, isSuperuser} = (req.user || {})
+        let user = req.user && { email, firstName, lastName, isSuperuser }
+        return res.status(200).send({ user })
     })
 
     app.post('/login', passport.authenticate('local'), function (req, res) {

--- a/test/auth.js
+++ b/test/auth.js
@@ -95,11 +95,12 @@ describe('session stuff' , function () {
         return User.sync({ force: true })
     })
 
-    it('/user should return 400 for nonlogins', function (done) {
-        chai.request(app).get('/user').send()
-            .end( function (error, response) {
-                expect(response.status).equal(400)
-                done()
+    it('/user should return empty user for nonlogins', function () {
+        return chai.request(app).get('/user').send()
+            .then(function (res) {
+                expect(res.status).to.equal(200)
+                expect(res).to.be.json
+                expect(res.body).to.not.include('user')
             })
     })
 
@@ -121,10 +122,13 @@ describe('session stuff' , function () {
                     .end(function (err, res) {
                         res.status.should.be.equal(200)
                         expect(res).to.be.json // <- this actually works O_o
-                        expect(res.body).to.deep.include({
-                            firstName: goodGuyGreg.firstName,
-                            lastName: goodGuyGreg.lastName,
-                            email: goodGuyGreg.email
+                        expect(res.body).to.deep.equal({
+                            user: {
+                                firstName: goodGuyGreg.firstName,
+                                lastName: goodGuyGreg.lastName,
+                                email: goodGuyGreg.email,
+                                isSuperuser: false
+                            }
                         })
                         done()
                     })
@@ -152,9 +156,12 @@ describe('session stuff' , function () {
                                 res.status.should.be.equal(200)
                                 expect(res).to.be.json
                                 expect(res.body).to.deep.include({
-                                    firstName: goodGuyGreg.firstName,
-                                    lastName: goodGuyGreg.lastName,
-                                    email: goodGuyGreg.email
+                                    user: {
+                                        firstName: goodGuyGreg.firstName,
+                                        lastName: goodGuyGreg.lastName,
+                                        email: goodGuyGreg.email,
+                                        isSuperuser: false
+                                    }
                                 })
                                 done()
                             })
@@ -212,7 +219,8 @@ describe('/logout', function () {
                                 res.status.should.be.equal(200)
                                 agent.get('/user').send()
                                     .end(function (error, res) {
-                                        res.status.should.be.equal(400)
+                                        res.status.should.be.equal(200)
+                                        expect(res.body.user).to.be.undefined
                                         done()
                                     })
                             })


### PR DESCRIPTION
`/user` now always returns 200 with body `{user: <object or undefined>}`