### PR TITLE
Dan view anon ticket

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "mixpanel-browser": "^2.11.1",
     "prop-types": "^15.5.10",
+    "query-string": "^4.3.4",
     "react": "^15.5.4",
     "react-bootstrap": "^0.31.0",
     "react-dom": "^15.5.4",

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -26,9 +26,10 @@
   border-bottom: 4px #0C120C solid;
 }
 
-.admin-footer a {
-  display: inline;
-  margin: 0px 20px;
+#user-action-menu {
+  background: none;
+  border: none;
+  box-shadow: none;
 }
 
 pallete {

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,11 +1,10 @@
 import React, { Component } from 'react';
 import { Route, Link } from 'react-router-dom';
-import { Button } from 'react-bootstrap';
 
-import Strings from './strings';
 import Login from './components/login'
+import LoginContainer from './components/loginContainer'
 import { routes } from './routes';
-import { getUser, logout } from './api.js'
+import { getUser, getTickets } from './api.js'
 
 
 import './App.css';
@@ -19,19 +18,19 @@ class App extends Component {
             user: null
         }
     }
+    receivedUser = (user) => {
+        this.setState({
+            showLogin: false,
+            user
+        })
 
-    getUser () {
-        getUser().then((user) => {
-            this.setState({user})
+        getTickets().then((tickets) => {
+            this.setState({ticketsCount: tickets.length });
         })
     }
 
-    logout() {
-        logout();
-    }
-
     componentDidMount () {
-        this.getUser()
+        getUser().then(this.receivedUser)
     }
 
     renderRoute = (route) => {
@@ -44,47 +43,23 @@ class App extends Component {
     return (
       <div className="App">
           <div className="App-header">
+            <Link to="">
               <img src={ process.env.PUBLIC_URL + '/img/logo_alpha.png'} className="App-logo" alt="logo" />
+            </Link>
           </div>
-          { !this.state.user && (
-              <div className="login-container">
-                  <a className="inline" href="javascript:void(0)" onClick={() => this.setState({showLogin: true})} >
-                    { Strings.header.loginAction }
-                  </a>
-              </div>
-          )}
 
-          { this.state.user && (
-              <div className="login-container">
-                  <p className="inline logged-in-header">{Strings.header.welcome}, {this.state.user.firstName} !</p> <span>
-                        <a className="inline logout-header" href="javascript:void(0)" onClick={() => this.logout()}>{Strings.header.logout}</a></span>
-              </div>
-          )}
+          <LoginContainer
+            onLogin = { () => this.setState({showLogin: true})}
+            user={ this.state.user }/>
 
           <Login
               onHide={ () => { this.setState({showLogin: false}) } }
               show={this.state.showLogin}
-              onLogin={ (user) => {
-                  this.setState({
-                      showLogin: false,
-                      user
-                  })
-              }}
-          />
+              onLogin={ this.receivedUser } />
             {routes.map((route,index) => (
                 <Route path={ route.path } key={index} exact={ route.exact } render={ this.renderRoute(route) } />
 
             ))}
-        { this.state.user && this.state.user.isSuperuser && (
-            <div className="admin-footer">
-              <hr />
-            <Link to='/'>MAIN</Link>
-            &nbsp;|&nbsp;
-            <Link to='/tickets'>TICKET ADMIN </Link>
-            &nbsp;|&nbsp;
-            <Link to='/admin/frequent-problems'>FREQUENT PROBLEM ADMIN </Link>
-          </div>
-        )}
         <div className="carmonication-footer"> Made by Carmonication 2017</div>
       </div>
     );

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -61,8 +61,8 @@ module.exports.createTicket = function(details) {
     return post('/ticket', details)
 }
 
-module.exports.getTicket = function(ticketId) {
-    return get(`/tickets/${ticketId}`)
+module.exports.getTicket = function(ticketId, accessToken) {
+    return get(`/tickets/${ticketId}?accessToken=${accessToken}`)
 }
 
 module.exports.getTickets = function () {

--- a/client/src/components/frequentProblems/footer.js
+++ b/client/src/components/frequentProblems/footer.js
@@ -3,34 +3,12 @@ import { Link } from 'react-router-dom';
 import { Button,  ButtonToolbar, Glyphicon} from 'react-bootstrap';
 import { NewTicketButton } from '../common';
 import Strings from '../../strings.js'
-import { getTickets } from '../../api'
 
 import './frequentProblems.css'
 
 export default class Footer extends Component {
     constructor(props){
         super(props);
-
-        this.state = {
-            ticketsCount: 0,
-            user: props.user
-        }
-    }
-
-    componentWillReceiveProps (newProps) {
-        if (newProps.user !== this.state.user) {
-            this.updateTicketCount()
-        }
-    }
-
-    updateTicketCount () {
-        getTickets().then((tickets) => {
-            this.setState({ticketsCount: tickets.length });
-        })
-    }
-
-    componentWillMount(){
-        this.updateTicketCount()
     }
 
     render() {
@@ -41,16 +19,6 @@ export default class Footer extends Component {
                     <p className="call-us"> { Strings.frequentProblems.callTech }</p>
                     <NewTicketButton />
                 </ButtonToolbar>
-
-                {this.state.ticketsCount > 0 &&
-                    <ButtonToolbar>
-                        <Link to="/tickets" >
-                            <Button  bsStyle="info">
-                                {Strings.TicketsList.viewTickets}
-                            </Button>
-                        </Link>
-                    </ButtonToolbar>
-                }
             </div>
         );
     }

--- a/client/src/components/frequentProblems/footer.js
+++ b/client/src/components/frequentProblems/footer.js
@@ -11,13 +11,26 @@ export default class Footer extends Component {
     constructor(props){
         super(props);
 
-        this.state = { ticketsCount : 0 }
+        this.state = {
+            ticketsCount: 0,
+            user: props.user
+        }
     }
 
-    componentWillMount(){
+    componentWillReceiveProps (newProps) {
+        if (newProps.user !== this.state.user) {
+            this.updateTicketCount()
+        }
+    }
+
+    updateTicketCount () {
         getTickets().then((tickets) => {
             this.setState({ticketsCount: tickets.length });
         })
+    }
+
+    componentWillMount(){
+        this.updateTicketCount()
     }
 
     render() {

--- a/client/src/components/loginContainer.js
+++ b/client/src/components/loginContainer.js
@@ -1,0 +1,117 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import { Dropdown, MenuItem} from 'react-bootstrap';
+
+import Strings from '../strings';
+import { logout } from '../api'
+
+export default class LoginContainer extends React.Component {
+    constructor(props, context) {
+        super(props)
+        this.context = context
+        this.state = {
+            user: props.user
+        }
+        this.allItems = this.adminItems.concat(this.userItems)
+    }
+
+    adminItems = [
+
+        (
+            <MenuItem header>{Strings.header.admin}</MenuItem>
+        ),
+
+        (
+            <MenuItem eventKey="10" >
+              <Link to="/admin/frequent-problems"
+                    className="inline">
+                {Strings.header.adminFrequentProblems}
+              </Link>
+            </MenuItem>
+        ),
+
+        (
+            <MenuItem divider />
+        )
+
+    ]
+
+    userItems = [
+        (
+            <MenuItem  eventKey="1" >
+              <Link to="/new-ticket"  className="inline">
+                {Strings.header.newTicket}
+              </Link>
+            </MenuItem>
+        ),
+
+        (
+            <MenuItem  eventKey="2" >
+              <Link to="/tickets"  className="inline">
+                {Strings.header.viewTickets}
+              </Link>
+            </MenuItem>
+        ),
+
+        (
+            <MenuItem divider />
+        ),
+
+        (
+            <MenuItem  eventKey="2" onClick={() => logout()}>
+              {Strings.header.logout}
+            </MenuItem>
+        ),
+    ]
+
+    componentWillReceiveProps(newProps) {
+        this.setState({
+            user: newProps.user
+        })
+    }
+
+    render () {
+        return this.state.user
+            ? this.renderUser()
+            : this.renderAnon()
+    }
+
+    renderAnon() {
+        return (
+            <div className="login-container">
+              <a className="inline"
+                 href="javascript:void(0)"
+                 onClick={this.props.onLogin} >
+                { Strings.header.loginAction }
+              </a>
+            </div>
+        )
+    }
+
+    renderUser() {
+
+        let items = this.state.user.isSuperuser
+            ? this.allItems
+            : this.userItems
+
+        return (
+
+            <div className="login-container">
+              <p className="inline logged-in-header"> {Strings.header.welcome}, {this.state.user.firstName} !</p>
+              <Dropdown
+                className="user-actions-menu logged-in-header"
+                bsSize="normal"
+                id="user-action-menu">
+                <Dropdown.Toggle>
+                  { Strings.header.userActions }
+                </Dropdown.Toggle>
+                <Dropdown.Menu>
+
+                  { items }
+
+                </Dropdown.Menu>
+              </Dropdown>
+            </div>
+        )
+    }
+}

--- a/client/src/components/newTicket/index.js
+++ b/client/src/components/newTicket/index.js
@@ -64,8 +64,6 @@ export default class NewTicket extends React.Component {
                   { Strings.ticket.watchMyTicket }
                 </Button>
               </Link>
-              <br/>
-              <BackToFrequentBtn></BackToFrequentBtn>
             </div>
             )
     }

--- a/client/src/components/newTicket/index.js
+++ b/client/src/components/newTicket/index.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import {Row, Col, Form, FormGroup, FormControl, ControlLabel, Button} from 'react-bootstrap'
+import { Link } from 'react-router-dom'
 
 import Strings from '../../strings';
 
@@ -34,10 +35,12 @@ export default class NewTicket extends React.Component {
         const { name, phone, room, content, subject } = this.state
         this.setState({isLoading: true})
         createTicket({name, phone, room, content, subject})
-            .then( () =>  {
+            .then( ({ id, accessToken }) => {
                 this.setState({
                     isLoading: false,
-                    submitted: true
+                    submitted: true,
+                    ticketId: id,
+                    accessToken
                 })
             })
     }
@@ -50,9 +53,17 @@ export default class NewTicket extends React.Component {
     }
 
     renderSubmitted = () => {
+        const { ticketId, accessToken } = this.state
+        const ticketUrl = `view-ticket/${ticketId}?accessToken=${accessToken}`
         return (
             <div>
               { Strings.ticket.sent }
+              <br/>
+              <Link to={ ticketUrl }>
+                <Button bsStyle="primary">
+                  { Strings.ticket.watchMyTicket }
+                </Button>
+              </Link>
               <br/>
               <BackToFrequentBtn></BackToFrequentBtn>
             </div>

--- a/client/src/components/ticketsAdmin/index.js
+++ b/client/src/components/ticketsAdmin/index.js
@@ -65,7 +65,7 @@ export default class TicketsAdmin extends React.Component {
                 <th >{ user ? `${user.firstName} ${user.lastName}` : ''}     </th>
                 <th >{ ticket.details.name }     </th>
                 <th  >
-                  <Link to={ `/view-ticket/${ticket.id}` }>
+                  <Link to={ `/view-ticket/${ticket.id}?accessToken=${ticket.accessToken}` }>
                     { ticket.details.subject }
                   </Link>
                 </th>

--- a/client/src/components/ticketsList/index.js
+++ b/client/src/components/ticketsList/index.js
@@ -73,7 +73,7 @@ export default class TicketsList extends React.Component {
         return (
             <tr  key={ ticket.id } >
                 <th>{ ticket.id }       </th>
-                <th >{ user ? `${user.firstName} ${user.lastName}` : ''}     </th>
+                <th >{ `${user.firstName || ''} ${user.lastName || ''}`} </th>
                 <th >{ ticket.details.name }     </th>
                 <th  >
                   <Link to={ `/view-ticket/${ticket.id}?accessToken=${ticket.accessToken}` }>

--- a/client/src/components/ticketsList/index.js
+++ b/client/src/components/ticketsList/index.js
@@ -23,6 +23,12 @@ export default class TicketsList extends React.Component {
             })
     }
 
+    componentWillReceiveProps (newProps) {
+        this.setState({
+            user: newProps.user
+        })
+    }
+
     componentDidMount () {
         this.reload()
     }
@@ -30,7 +36,9 @@ export default class TicketsList extends React.Component {
     render () {
         return (
             <div>
-              <h1>{ strings.TicketsList.headline }</h1>
+              { this.state.user && (
+                <h1>{ strings.TicketsList.headline[this.state.user.isSuperuser ? 'admin' : 'user'] }</h1>
+              )}
               <Table className="center centered" striped bordered condensed hover>
                 <thead>
                   <tr>

--- a/client/src/components/viewTicket/index.js
+++ b/client/src/components/viewTicket/index.js
@@ -17,6 +17,8 @@ export default class ViewTicket extends React.Component {
         this.state = {
             newUpdateText: '',
             accessToken: accessToken,
+            isLoggedUser: props.user,
+            isSuperuser: props.user && props.user.isSuperuser,
             ticket: {
                 id: '',
                 user: {},
@@ -24,10 +26,6 @@ export default class ViewTicket extends React.Component {
                 ticket_updates: []
             }
         }
-    }
-
-    goBack() {
-        this.props.history.goBack()
     }
 
     componentDidMount () {
@@ -168,6 +166,7 @@ export default class ViewTicket extends React.Component {
     }
     componentWillReceiveProps (newProps) {
         this.setState({
+            isLoggedUser: newProps.user,
             isSuperuser: newProps.user && newProps.user.isSuperuser
         })
     }
@@ -215,10 +214,6 @@ export default class ViewTicket extends React.Component {
         const user = this.state.ticket.user
         const userDetails =  user ? `${user.firstName} ${user.lastName} (${user.email})` : ''
         const ticketUpdates = this.state.ticket.ticket_updates || []
-        const linkBack = this.state.isSuperuser
-              ? '/admin/tickets'
-              : '/'
-
 
         return (
             <div>
@@ -248,7 +243,7 @@ export default class ViewTicket extends React.Component {
               <hr/>
               { this.renderUpdatesTable() }
               <hr/>
-              <a href="javascript:void(0)" onClick={ ()=> { this.goBack() } }>{ strings.back }</a>
+              <Link to={ this.state.isLoggedUser ? '/tickets' : '/' } > { strings.back } </Link>
             </div>
         )
     }

--- a/client/src/components/viewTicket/index.js
+++ b/client/src/components/viewTicket/index.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import queryString from 'query-string'
+import { browserHistory } from 'react-router'
 import { Link } from 'react-router-dom'
 import { Table, Col, Row, FormGroup, Form, FormControl, ControlLabel, Button} from 'react-bootstrap'
 
@@ -23,6 +24,10 @@ export default class ViewTicket extends React.Component {
                 ticket_updates: []
             }
         }
+    }
+
+    goBack() {
+        this.props.history.goBack()
     }
 
     componentDidMount () {
@@ -243,7 +248,7 @@ export default class ViewTicket extends React.Component {
               <hr/>
               { this.renderUpdatesTable() }
               <hr/>
-              <Link to={ linkBack }>{ strings.back }</Link>
+              <a href="javascript:void(0)" onClick={ ()=> { this.goBack() } }>{ strings.back }</a>
             </div>
         )
     }

--- a/client/src/components/viewTicket/index.js
+++ b/client/src/components/viewTicket/index.js
@@ -192,6 +192,20 @@ export default class ViewTicket extends React.Component {
             </Form>
         )
     }
+    renderUpdatesTable () {
+        const updates = this.state.ticket.ticket_updates.length > 0
+              ?  this.state.ticket.ticket_updates.map(this.renderTicketUpdate)
+              : strings.ticket.noUpdates
+        return (
+            <div className="updates">
+              <h2>{ strings.ticket.updates } </h2>
+              { this.state.isSuperuser && this.renderNewUpdateForm() }
+              { updates }
+            </div>
+
+        )
+    }
+
     render () {
         const user = this.state.ticket.user
         const userDetails =  user ? `${user.firstName} ${user.lastName} (${user.email})` : ''
@@ -227,12 +241,7 @@ export default class ViewTicket extends React.Component {
               </Table>
 
               <hr/>
-              <div className="updates">
-                <h2>{ strings.ticket.updates } </h2>
-                { this.state.isSuperuser && this.renderNewUpdateForm() }
-                { this.state.ticket.ticket_updates.map(this.renderTicketUpdate) }
-
-              </div>
+              { this.renderUpdatesTable() }
               <hr/>
               <Link to={ linkBack }>{ strings.back }</Link>
             </div>

--- a/client/src/components/viewTicket/index.js
+++ b/client/src/components/viewTicket/index.js
@@ -150,17 +150,17 @@ export default class ViewTicket extends React.Component {
         )
     }
 
-    renderField = (field,index) => {
-        return this.renderTicketInfo(field, this.state.ticket.details[field], index)
+    renderField = (field) => {
+        return this.renderTicketInfo(field, this.state.ticket.details[field])
     }
 
-    renderTicketInfo = (name, value, index) => {
+    renderTicketInfo = (name, value, opts = {}) => {
         return (
-            <tr key={index || Math.random()}>
+            <tr key={name || Math.random()}>
               <td className="main-column">
                 { strings.ticket[name] }
               </td>
-              <td className="value-column">
+              <td className={`value-column ${opts.leftToRight && 'ltr'}` }>
                 { value }
               </td>
             </tr>
@@ -228,10 +228,10 @@ export default class ViewTicket extends React.Component {
               </h1>
               <Table className="ticket-view-table" condensed>
                 <tbody>
-                  { Object.keys(this.state.ticket.details).map( (field, index) => this.renderField(field, index) ) }
+                  { Object.keys(this.state.ticket.details).map( (field) => this.renderField(field) ) }
 
                   { this.renderTicketInfo('user', userDetails) }
-                  { this.renderTicketInfo('dateIssued',  this.formatDate(this.state.ticket.createdAt)) }
+                  { this.renderTicketInfo('dateIssued',  this.formatDate(this.state.ticket.createdAt), {leftToRight: true})}
 
                   <tr>
                     <td className="main-column">

--- a/client/src/components/viewTicket/viewTicket.css
+++ b/client/src/components/viewTicket/viewTicket.css
@@ -4,6 +4,9 @@
 .ticket-update-text {
   border: 1px solid black;
 }
+.ticket-update-status {
+  font-style: italic;
+}
 
 .ticket-view-table {
   margin: auto;

--- a/client/src/strings.js
+++ b/client/src/strings.js
@@ -49,6 +49,7 @@ export default {
     },
     back: 'חזרה',
     ticket: {
+        headlinePrefix: 'קריאה #',
         watchMyTicket: 'למעקב אחר הקריאה שלי',
         user: 'משתמש',
         dateIssued: 'תאריך יצירה',

--- a/client/src/strings.js
+++ b/client/src/strings.js
@@ -1,8 +1,13 @@
 export default {
     loading: 'טוען...',
     header:{
+        admin: 'ניהול',
+        adminFrequentProblems: 'תקלות נפוצות',
+        viewTickets: 'צפייה בקריאות שלי',
+        newTicket: 'פתיחת קריאה חדשה',
+        userActions: 'פעולות',
         loginAction: 'כניסה',
-        logout: 'התנתק/י',
+        logout: 'התנתקות',
         welcome: 'שלום '
 
     },
@@ -85,7 +90,6 @@ export default {
             admin: 'ניהול קריאות',
             user: 'הקריאות שלי'
         },
-        viewTickets: 'צפייה בקריאות שלי',
         reload: 'רענן'
     }
 }

--- a/client/src/strings.js
+++ b/client/src/strings.js
@@ -49,6 +49,7 @@ export default {
     },
     back: 'חזרה',
     ticket: {
+        watchMyTicket: 'למעקב אחר הקריאה שלי',
         user: 'משתמש',
         dateIssued: 'תאריך יצירה',
         dateUpdated: 'תאריך עדכון',

--- a/client/src/strings.js
+++ b/client/src/strings.js
@@ -49,6 +49,7 @@ export default {
     },
     back: 'חזרה',
     ticket: {
+        noUpdates: 'אין עדכונים לקריאה זו.',
         headlinePrefix: 'קריאה #',
         watchMyTicket: 'למעקב אחר הקריאה שלי',
         user: 'משתמש',

--- a/client/src/strings.js
+++ b/client/src/strings.js
@@ -81,7 +81,10 @@ export default {
         openTicketHeader:'פתח קריאה חדשה'
     },
     TicketsList: {
-        headline: 'ניהול קריאות',
+        headline: {
+            admin: 'ניהול קריאות',
+            user: 'הקריאות שלי'
+        },
         viewTickets: 'צפייה בקריאות שלי',
         reload: 'רענן'
     }

--- a/migrations/20170621224658-add-access-token-to-tickets.js
+++ b/migrations/20170621224658-add-access-token-to-tickets.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = {
+  up: function (queryInterface, Sequelize) {
+      return queryInterface.addColumn('tickets', 'accessToken', Sequelize.STRING)
+  },
+
+  down: function (queryInterface, Sequelize) {
+      return queryInterface.removeColumn('tickets', 'accessToken')
+  }
+};

--- a/models/ticket.js
+++ b/models/ticket.js
@@ -17,9 +17,13 @@ module.exports = function (sequelize) {
             validate: {
                 isIn: [['open', 'closed', 'inTherapy']]
             }
-        }
+        },
+        accessToken: Sequelize.STRING
     }, {
         hooks: {
+            beforeCreate: function (ticket, attributes) {
+                ticket.accessToken = Math.random().toString(36).substring(2)
+            },
             afterCreate: function (ticket) {
                 notifyNewTicket(ticket)
             }

--- a/notifications.js
+++ b/notifications.js
@@ -18,6 +18,6 @@ module.exports.notifyNewTicket = function (ticket) {
     if (!ticket.id) {
         throw 'Cannot notify about a ticket with no id'
     }
-    const ticketLink = `${hostname}/view-ticket/${ticket.id}`
+    const ticketLink = `${hostname}/view-ticket/${ticket.id}?accessToken=${ticket.accessToken}`
     notify({text: `A new ticket has been opened:\n"${ticket.details.name} at room #${ticket.details.room}"\n<${ticketLink}|More Details>`})
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "bclient": "cd client && npm run build",
     "iclient": "cd client && npm i",
     "resetdb": "node db/reset_db && sequelize db:seed:all",
-    "migrate": "sequelize db:migrate",
+    "migrate": "node_modules/.bin/sequelize db:migrate",
     "superman": "node scripts/update_superuser"
   },
   "author": "",

--- a/test/models/Ticket.js
+++ b/test/models/Ticket.js
@@ -76,4 +76,24 @@ describe('Ticket model', function () {
                 expect(ticket.ticket_updates).to.have.lengthOf(1)
             })
     })
+
+    it('should be created with random access tokens', function () {
+        const COUNT = 100
+        const accessTokens = []
+        const tickets = Array.from(new Array(COUNT))
+              .map( _ => Ticket.create()
+                    .then(
+                        ticket => accessTokens.push(ticket.accessToken)
+                    )
+                  )
+        return Promise.all(tickets)
+            .then( function () {
+                const keys = {}
+                accessTokens.forEach(function (accessToken) {
+                    expect(keys[accessToken]).to.be.undefined
+                    accessTokens[accessToken] = 'EXISTS!'
+                })
+            })
+    })
+
 })

--- a/test/routes/tickets.js
+++ b/test/routes/tickets.js
@@ -117,9 +117,7 @@ describe('POST /ticket', function () {
                     content: 'I have problem',
                     room: '101'
                 })
-                // TODO check the ticket's TicketUpdate array somehow
             })
-            // .catch( (e) => {console.error(e); throw e})
     })
 
 })
@@ -128,7 +126,7 @@ describe('GET /ticket/:id', function () {
     beforeEach(makeGreg)
     beforeEach(clearTickets)
 
-    it('should not work without superuser login', function (done) {
+    it('should not work without superuser or access token', function (done) {
         const agent = chai.request.agent(app)
         let ticketId
         Ticket.create({
@@ -143,7 +141,7 @@ describe('GET /ticket/:id', function () {
                 })
 
                     .then(function () {
-                        agent.get(`/tickets/${ticketId}`)
+                        agent.get(`/tickets/${ticketId}?accessToken=wildguess`)
                             .send()
                             .end(function (error, response) {
                                 expect(response.status).to.equal(401)
@@ -206,7 +204,7 @@ describe('GET /ticket/:id', function () {
             .catch( (e) => {console.error(e); throw e})
     })
 
-    it('should return ticket information when given correct accessKey', function () {
+    it('should return ticket information when given correct access token', function () {
         const agent = chai.request.agent(app)
 
         return Ticket.create({

--- a/test/routes/tickets.js
+++ b/test/routes/tickets.js
@@ -220,9 +220,6 @@ describe('GET /ticket/:id', function () {
                     .send()
             })
             .then(function (response) {
-
-                console.log('<-DANDEBUG-> tickets.js\\ 224: response.status:', response.status);
-                console.log('<-DANDEBUG-> tickets.js\\ 225: response.body:', response.body);
                 response.status.should.equal(200)
                 expect(response).to.be.json
                 response.should.be.json


### PR DESCRIPTION
 ## FEATURES

### Anonymous Ticket View
 - Ticket now has an `accessToken` field which is automatically randomly generated upon creation
 - Using this access token it is possible to view the ticket without authentication
 - After a user creates a ticket, she is given a link button to see the view-ticket page
 - When a regular/anonymous user sees the ticket-view page (with correct access token), she can see everything but **cannot send updates** or change status
### Login Container
Login container, where the logged-in user name appears, now features a combobox for all possible actions, including admin if the user is Ella or her minion.
This also replaces all the english links we used to have at the bottom.

## OTHER CHANGES
- Fixed `npm migrate` to use locally installed Sequelize CLI
- Headline in ticket-view now specified in strings, rather than in the component...
- Fixed headline for admin OR user in newly introduced ticket list
- Fixed minor bug in frequent problems - now it shows the My-Tickets button if the user logs in after loading
- LTR date in ticket view
## NOT IMPLEMENTED
- An anonymous/regular user cannot update a ticket even with an access token
